### PR TITLE
Add 'only when playing' config option

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,8 @@ Options:
           Will use the "watching" activity. Use multiple times to add several players
       --hide-album-name
           Hide album name
+      --only-when-playing
+          Only send activity when media is playing
   -d, --disable-cache
           Disable cache (not recommended)
       --lastfm-api-key <api_key>

--- a/src/main.rs
+++ b/src/main.rs
@@ -371,6 +371,12 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 playback_status
             );
 
+            if settings.only_when_playing && !is_playing {
+                is_interrupted = true;
+                utils::clear_activity(&mut is_activity_set, client);
+                sleep(Duration::from_secs(interval));
+                continue;
+            }
             // Parse metadata
             let title = metadata.title().unwrap_or("Unknown Title");
             let mut album = metadata.album_name().unwrap_or("Unknown Album");

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -62,6 +62,10 @@ pub struct Cli {
     #[arg(long)]
     pub hide_album_name: bool,
 
+    /// Only send activity when media is playing
+    #[arg(long)]
+    pub only_when_playing: bool,
+
     /// Disable cache (not recommended)
     #[arg(short, long)]
     pub disable_cache: bool,


### PR DESCRIPTION
Adds a setting to only send activity when media is actively playing. I wanted this tweak since it's how Spotify does things.